### PR TITLE
Fixed casing of EndUserID

### DIFF
--- a/src/domain/methods/registeraccount/RegisterAccountRequestData.ts
+++ b/src/domain/methods/registeraccount/RegisterAccountRequestData.ts
@@ -7,7 +7,7 @@ export interface RegisterAccountRequestData extends AbstractToTrustlyRequestData
    * ID, username, hash or anything uniquely identifying the end-user to be identified. Preferably the same ID/username as used in the
    * merchant's own backoffice in order to simplify for the merchant's support department
    */
-  EndUserId: string;
+  EndUserID: string;
 
   /**
    * The clearing house of the end-user's bank account. Typically the name of a country in uppercase letters. See table


### PR DESCRIPTION
With the current casing `EndUserId` the call will fail with: 

```json
{"message": "ERROR_INVALID_PARAMETERS","code": 623}
```

When using the correct casing `EndUserID` the call works.