### PR TITLE
Calculate correct content length for UTF-8 string

### DIFF
--- a/src/request/NodeJsHttpRequester.ts
+++ b/src/request/NodeJsHttpRequester.ts
@@ -16,7 +16,7 @@ export class NodeJsHttpRequester implements HttpRequester {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Content-Length': request.length,
+            'Content-Length': Buffer.byteLength(request, 'utf8'),
           },
         },
         response => {


### PR DESCRIPTION
By using `Content-Length: request.length`, you risk telling the server the wrong byte‐count. Consider this payload:

```js
const response = await client.registerAccount({
  Firstname: "Christöffer",
  Lastname: "Skeppstedt",
  ...
});
```

When the string contains an "ö" instead of "o", we have:
- Byte count: 930
- String length: 929

When this request is sent to the Trustly API, it responds back with:

```json
{
  "name": "JSONRPCError",
  "code": 101,
  "message": "ERROR_MALFORMED_JSON"
}
```

This is likely because the content length header is incorrect (929 != 930). When instead using `Content-Length: Buffer.byteLength(request, 'utf8')`, we get the correct content lenght, and the request is accepted.