### PR TITLE
Fix response types for account payout

### DIFF
--- a/src/domain/methods/accountpayout/AccountPayoutResponseData.ts
+++ b/src/domain/methods/accountpayout/AccountPayoutResponseData.ts
@@ -6,7 +6,7 @@ export interface AccountPayoutResponseData extends AbstractResponseResultData {
   /**
    * The globally unique OrderID the account payout order was assigned in our system.
    */
-  orderId: number; // long
+  orderid: string; // long
 
   /**
    * "1" if the payout could be accepted and "0" otherwise.


### PR DESCRIPTION
The reponse object from the API actually looks like this:

```json
{
  "orderid": "13350746106",
  "result": "1"
}
```

So I updated the casing and the type to match it.